### PR TITLE
Fix function links in documentation

### DIFF
--- a/2.0/_sidebar.md
+++ b/2.0/_sidebar.md
@@ -5,14 +5,14 @@
 
 **Functions**
 
--   [ScribbleJr](ScribbleJr)
--   [ScribbleJrFit](ScribbleJrFit)
--   [ScribbleJrShrink](ScribbleJrShrink)
--   [ScribbleJrExt](ScribbleJrExt)
--   [ScribbleJrFitExt](ScribbleJrFitExt)
--   [ScribbleJrShrinkExt](ScribbleJrShrinkExt)
--   [ScribbleJrDrawNative](ScribbleJrDrawNative)
--   [ScribbleJrResetDrawState](ScribbleJrResetDrawState)
+-   [ScribbleJr](Scribblejr)
+-   [ScribbleJrFit](ScribblejrFit)
+-   [ScribbleJrShrink](ScribblejrShrink)
+-   [ScribbleJrExt](ScribblejrExt)
+-   [ScribbleJrFitExt](ScribblejrFitExt)
+-   [ScribbleJrShrinkExt](ScribblejrShrinkExt)
+-   [ScribbleJrDrawNative](ScribblejrDrawNative)
+-   [ScribbleJrResetDrawState](ScribblejrResetDrawState)
 
 ---
 


### PR DESCRIPTION
Function links were broken due to capitalization.